### PR TITLE
Redesign skill as /lnb with sub-commands, onboarding, and UX improvements

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,10 +66,10 @@ Set `LAB_NOTEBOOK_WRITER` only if they provide a value different from `$USER`.
 First check if the notebook already exists:
 
 ```bash
-ls "$LAB_NOTEBOOK_DIR/schema.yaml" 2>/dev/null && echo "EXISTS" || echo "NEW"
+test -f "$LAB_NOTEBOOK_DIR/schema.yaml" && echo "EXISTS" || echo "NEW"
 ```
 
-- If `EXISTS`: tell the user "Notebook already initialized at `<path>` — skipping init." Proceed to Step 4.
+- If `EXISTS`: tell the user "Notebook already initialized at `<path>` — skipping init." Proceed to Step 3.
 - If `NEW`: run:
 
 ```bash
@@ -157,6 +157,8 @@ If it is, present the user with options **before** drafting the emit command:
 
 Wait for the user's choice before proceeding.
 
+If user picks **A**, ask: "What file should I attach?" Then use the path as `--artifacts <path>` in Step 4.
+
 ### Step 4: Draft and confirm
 
 ```bash
@@ -174,7 +176,7 @@ Present for confirmation, showing the actual notebook path:
 > **Type**: decision | **Context**: ssl/pretraining
 >
 > ```bash
-> lab-notebook emit --context ssl/pretraining --type decision "..."
+> lab-notebook emit --context ssl/pretraining --type decision [--artifacts <path>] "..."
 > ```
 >
 > OK to emit, or adjust?


### PR DESCRIPTION
## Summary

- Renames the skill from `lab-notebook` to `lnb` with explicit sub-commands: `/lnb log`, `/lnb recall`, `/lnb onboard`
- Replaces `RESEARCH_DIR` indirection with native `LAB_NOTEBOOK_DIR` / `LAB_NOTEBOOK_WRITER` env vars
- Removes multi-campaign layout entirely — single notebook, context slugs for organization
- Adds guided onboarding with idempotency, error handling, and global default fallback (`~/lab-notebook`)
- Adds type inference from content keywords (with user confirmation before emit)
- Adds content-length check before logging: presents user with options (reference file, break up, distill)
- Adds empty `/lnb recall` default (recent 10 entries) and recovery suggestions when results are empty
- Fixes `$RESEARCH_DIR` leftover bug in Templates section
- Adds truncation guidance in Recall (default `substr()` for scanning, easy to drop for full content)

## Known deferred issues

- #1 — Onboard idempotency: check entries DB, not just `schema.yaml`
- #2 — Type inference: define priority when multiple keywords match
- #3 — Environment check: verify `lab-notebook` binary exists before any command

## Test plan

- [ ] `/lnb onboard` — walks through setup, initializes notebook, skips if already exists
- [ ] `/lnb log <content>` — infers type, picks context, confirms before emit
- [ ] `/lnb log` (no content) — prompts for content
- [ ] `/lnb log <long content>` — presents A/B/C options before drafting
- [ ] `/lnb recall <query>` — searches and summarizes
- [ ] `/lnb recall` (no args) — shows recent 10 entries
- [ ] `/lnb recall <query>` with no results — shows recovery suggestions
- [ ] `/lnb` (no args) — shows usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)