### PR TITLE
Fix Onboard flow for upstream .lnb subfolder change

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -115,17 +115,23 @@ Set `LAB_NOTEBOOK_WRITER` only if they provide a value different from `$USER`.
 
 ### Step 2: Initialize the notebook
 
-First check if the notebook already exists:
+First check if the notebook already exists. The CLI always creates a `.lnb/` subdirectory inside the given path:
 
 ```bash
-test -f "$LAB_NOTEBOOK_DIR/schema.yaml" && echo "EXISTS" || echo "NEW"
+test -f "$LAB_NOTEBOOK_DIR/.lnb/schema.yaml" && echo "EXISTS" || echo "NEW"
 ```
 
-- If `EXISTS`: tell the user "Notebook already initialized at `<path>` — skipping init." Proceed to Step 3.
+- If `EXISTS`: tell the user "Notebook already initialized at `<path>/.lnb/` — skipping init." Proceed to Step 3.
 - If `NEW`: run:
 
 ```bash
-mkdir -p "$LAB_NOTEBOOK_DIR" && lab-notebook init "$LAB_NOTEBOOK_DIR"
+lab-notebook init "$LAB_NOTEBOOK_DIR"
+```
+
+This creates the notebook at `$LAB_NOTEBOOK_DIR/.lnb/` and writes `.lnb.env` in the current directory. Since this is global setup, the `.lnb.env` file is not needed — clean it up:
+
+```bash
+rm -f .lnb.env
 ```
 
 If the init command fails (non-zero exit), tell the user:
@@ -136,16 +142,16 @@ Do not proceed past this step on failure.
 
 ### Step 3: Set and persist the environment
 
-First, export the variable in the current session so subsequent commands work immediately:
+The notebook lives at `<chosen path>/.lnb/`, so the env var must point there. Export in the current session:
 
 ```bash
-export LAB_NOTEBOOK_DIR="<chosen path>"
+export LAB_NOTEBOOK_DIR="<chosen path>/.lnb"
 ```
 
 Then tell the user to add to their shell profile (or a project `.env`) for future sessions:
 
 ```bash
-export LAB_NOTEBOOK_DIR="<chosen path>"
+export LAB_NOTEBOOK_DIR="<chosen path>/.lnb"
 export LAB_NOTEBOOK_WRITER="<username>"  # optional, defaults to $USER
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,13 +115,13 @@ Set `LAB_NOTEBOOK_WRITER` only if they provide a value different from `$USER`.
 
 ### Step 2: Initialize the notebook
 
-First check if the notebook already exists. The CLI always creates a `.lnb/` subdirectory inside the given path:
+First check if the notebook already exists. The CLI always creates a `.lnb/` subdirectory inside the given path. Check both locations to handle re-runs (where `LAB_NOTEBOOK_DIR` already ends in `.lnb`):
 
 ```bash
-test -f "$LAB_NOTEBOOK_DIR/.lnb/schema.yaml" && echo "EXISTS" || echo "NEW"
+(test -f "$LAB_NOTEBOOK_DIR/schema.yaml" || test -f "$LAB_NOTEBOOK_DIR/.lnb/schema.yaml") && echo "EXISTS" || echo "NEW"
 ```
 
-- If `EXISTS`: tell the user "Notebook already initialized at `<path>/.lnb/` — skipping init." Proceed to Step 3.
+- If `EXISTS`: tell the user "Notebook already initialized — skipping init." Proceed to Step 3.
 - If `NEW`: run:
 
 ```bash


### PR DESCRIPTION
## Summary
- Fixes the Onboard (global setup) flow broken by upstream `carbonscott/lab-notebook` PR #14, which changed `lab-notebook init <path>` to always create `<path>/.lnb/`
- Updates EXISTS check to look for `$LAB_NOTEBOOK_DIR/.lnb/schema.yaml`
- Removes unnecessary `mkdir -p`, adds `.lnb.env` cleanup for global setup
- Points `LAB_NOTEBOOK_DIR` at `<chosen path>/.lnb` in Step 3

Fixes #9

## Test plan
- [ ] Run `/lnb onboard` with a fresh path — verify notebook created at `<path>/.lnb/` and `lab-notebook schema` succeeds
- [ ] Run `/lnb onboard` with an existing notebook — verify EXISTS check detects it correctly
- [ ] Confirm no stray `.lnb.env` left in CWD after global onboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)