### PR TITLE
Fix SKILL.md: drop stale --local flag, add --template-path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,7 @@ Ask:
 ### Step 2: Run init
 
 ```bash
-lab-notebook init --local [<path>]
+lab-notebook init [<path>]
 ```
 
 Omit `<path>` to use the default `.lnb/`. The CLI will:
@@ -308,12 +308,17 @@ lab-notebook sql \
 # List available templates
 lab-notebook template
 
-# Initialize with a specific template
+# Initialize with a bundled template
 lab-notebook init "$LAB_NOTEBOOK_DIR" --template ml-experiment-log
+
+# Initialize with a schema file shipped by the current project
+lab-notebook init --template-path ./my-schema.yaml
 ```
 
 Bundled templates:
 - `research-notebook` (default) — observations, decisions, dead-ends, questions, milestones
 - `ml-experiment-log` — run-start, run-end, config-change, crash, checkpoint, comparison
+
+Use `--template-path` when your project ships its own schema file rather than relying on a bundled template. Mutually exclusive with `--template`.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary

- Drop `--local` from the Init → Step 2 example. The flag was removed upstream in [lab-notebook#13](https://github.com/carbonscott/lab-notebook/pull/13); init is now project-local by default, so the documented command line errored out.
- Document `--template-path` alongside the existing `--template` example in the Templates section. Added in [lab-notebook#16](https://github.com/carbonscott/lab-notebook/pull/16), this flag lets a project initialize a notebook directly from its own schema YAML.

Closes #11

## Test plan

- [x] `lab-notebook init --help` confirms `--template` / `--template-path` are mutually exclusive and `--local` is gone
- [x] `grep -- '--local' SKILL.md` returns no matches
- [x] `grep -- '--template-path' SKILL.md` returns the new Templates section entries
- [ ] Manual: `lab-notebook init` (no args) in a scratch dir creates `.lnb/` + `.lnb.env`
- [ ] Manual: `lab-notebook init --template-path ./some-schema.yaml` loads the external schema into `.lnb/schema.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)