### PR TITLE
Fix SKILL.md for new upstream discovery precedence (closes #13)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ Before executing any command (except `init` and `onboard` themselves), run the *
 
 ## Environment Check
 
-The CLI handles notebook discovery automatically (`.lnb.env` walk-up → `$LAB_NOTEBOOK_DIR` → error). Verify it can find a notebook:
+The CLI handles notebook discovery automatically (`$LAB_NOTEBOOK_DIR` → nearest `.lnb.env` walking up from CWD → error). Verify it can find a notebook:
 
 ```bash
 lab-notebook schema >/dev/null 2>&1 && echo "OK" || echo "NO_NOTEBOOK"
@@ -78,7 +78,22 @@ The CLI already suggests `.gitignore` additions in its output. If the user wants
 
 Wait for the user's preference before modifying `.gitignore`.
 
-### Step 4: Verify
+### Step 4: Check for a shadowing env var
+
+`$LAB_NOTEBOOK_DIR` takes precedence over `.lnb.env`. If it's already exported (e.g. from a shell profile or a prior `/lnb onboard`), the freshly-written project `.lnb.env` will be silently ignored.
+
+```bash
+[ -n "$LAB_NOTEBOOK_DIR" ] && echo "SHADOWED: $LAB_NOTEBOOK_DIR" || echo "OK"
+```
+
+- If `OK` → proceed to Step 5.
+- If `SHADOWED: <path>` → tell the user:
+
+> `$LAB_NOTEBOOK_DIR` is exported and points at `<path>`. The new project notebook won't be used until you either `unset LAB_NOTEBOOK_DIR` in this shell or remove the export from your shell profile.
+
+Wait for them to clear the env var (or confirm they want the global notebook to keep winning) before proceeding.
+
+### Step 5: Verify
 
 ```bash
 lab-notebook schema

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,9 +89,9 @@ Wait for the user's preference before modifying `.gitignore`.
 - If `OK` → proceed to Step 5.
 - If `SHADOWED: <path>` → tell the user:
 
-> `$LAB_NOTEBOOK_DIR` is exported and points at `<path>`. The new project notebook won't be used until you either `unset LAB_NOTEBOOK_DIR` in this shell or remove the export from your shell profile.
+> `$LAB_NOTEBOOK_DIR` is exported and points at `<path>`. The new project notebook won't be used until you remove the export from your shell profile and **restart Claude Code** — each `bash` tool call inherits env vars from Claude's own process, so unsetting it in your terminal (or inside a single tool call) won't propagate to the verify step below.
 
-Wait for them to clear the env var (or confirm they want the global notebook to keep winning) before proceeding.
+Wait for them to restart and re-run (or confirm they want the global notebook to keep winning) before proceeding.
 
 ### Step 5: Verify
 


### PR DESCRIPTION
## Summary
- Flip precedence description in Environment Check to match upstream (`$LAB_NOTEBOOK_DIR` → `.lnb.env` walk-up → error) after carbonscott/lab-notebook#18
- Add an Init step that detects when `$LAB_NOTEBOOK_DIR` is already exported (from a profile or prior onboard) and would silently shadow the freshly-written `.lnb.env`, prompting the user to clear it

Went with option B from the issue (detect-and-warn). Option C (`source .lnb.env`) would not persist across Claude Code's per-call subshells; option A (docs-only) doesn't surface the failure when it actually happens.

Closes #13.

## Test plan
- [ ] Trigger `/lnb init` in a directory with no `$LAB_NOTEBOOK_DIR` exported → `OK` branch fires, verify step proceeds
- [ ] Trigger `/lnb init` with `LAB_NOTEBOOK_DIR` exported to an unrelated path → `SHADOWED: <path>` branch fires, user is prompted before `lab-notebook schema` runs
- [ ] Confirm the Environment Check narration still accurately describes resolution order used by `lab-notebook schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)